### PR TITLE
Update default port to 9381

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN go install \
     github.com/cloudflare/kafka-zookeeper-exporter && \
     rm -fr /go/src
 
-EXPOSE 8080
+EXPOSE 9381
 
 CMD ["kafka-zookeeper-exporter"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To see the list of avaiable flags run
 
 Send a request to collect metrics
 
-    curl localhost:8080/kafka?target=10.0.0.1:2181&chroot=/kafka/cluster&topics=mytopic1,mytopic2
+    curl localhost:9381/kafka?target=10.0.0.1:2181&chroot=/kafka/cluster&topics=mytopic1,mytopic2
 
 Where:
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ const (
 var (
 	version = "unknown"
 
-	listenAddress = flag.String("web.listen-address", ":8080", "Address to listen on for web interface and telemetry.")
+	listenAddress = flag.String("web.listen-address", ":9381", "Address to listen on for web interface and telemetry.")
 	serverTimeout = flag.Duration("web.timeout", 60*time.Second, "Timeout for responding to HTTP requests.")
 	zkTimeout     = flag.Duration("zk.timeout", 5*time.Second, "Timeout for ZooKeeper requests")
 	showVersion   = flag.Bool("version", false, "Show version and exit")


### PR DESCRIPTION
9381 was allocated on https://github.com/prometheus/prometheus/wiki/Default-port-allocations, update code and docs to use it