### PR TITLE
Fix dups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ To see the list of avaiable flags run
 
 Send a request to collect metrics
 
-    curl localhost:9381/kafka?target=10.0.0.1:2181&chroot=/kafka/cluster&topics=mytopic1,mytopic2
+    curl localhost:9381/kafka?zookeeper=10.0.0.1:2181&chroot=/kafka/cluster&topics=mytopic1,mytopic2
 
 Where:
 
-* target - address of the ZooKeeper used for Kafka, can be multiple addresses separated by comma
+* zookeeper - address of the ZooKeeper used for Kafka, can be multiple addresses separated by comma
 * chroot - path inside ZooKeeper where Kafka cluster data is stored
 * topics - optional, list of topics to collect metrics for, if empty or missing then all topics will be collected

--- a/collector.go
+++ b/collector.go
@@ -55,7 +55,7 @@ func newCollector(target string, chroot string, topics []string) *collector {
 			partitionReplicaCount: prometheus.NewDesc(
 				"kafka_topic_partition_replica_count",
 				"Total number of replicas for this topic",
-				[]string{"topic"},
+				[]string{"topic", "partition"},
 				prometheus.Labels{},
 			),
 			partitionISR: prometheus.NewDesc(
@@ -100,6 +100,9 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_topic_list_error", msg, nil, nil), err)
 		return
 	}
+
+	// kafka_zookeeper_up{} 1
+	ch <- prometheus.MustNewConstMetric(c.metrics.kafkaUp, prometheus.GaugeValue, 1)
 
 	for _, topic := range topics {
 		if len(c.topics) > 0 && !stringInSlice(topic.Name, c.topics) {

--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ var (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	target := r.URL.Query().Get("target")
-	if target == "" {
-		http.Error(w, "'target' parameter must be specified", 400)
+	zookeeper := r.URL.Query().Get("zookeeper")
+	if zookeeper == "" {
+		http.Error(w, "'zookeeper' parameter must be specified", 400)
 		return
 	}
 
@@ -46,7 +46,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(newCollector(target, chroot, topics))
+	registry.MustRegister(newCollector(zookeeper, chroot, topics))
 
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)
@@ -73,7 +73,7 @@ func main() {
 		<head><title>Kafka ZooKeeper Exporter</title></head>
 		<body>
 		<p><a href='` + metricsRoute + `'>Metrics</a></p>
-		<p><a href='` + probeRoute + `?target=zookeeper1.local:2181&chroot=/path'>Example Kafka ZooKeeper probe</a></p>
+		<p><a href='` + probeRoute + `?zookeeper=zookeeper1.local:2181&chroot=/path'>Example Kafka ZooKeeper probe</a></p>
 		</body>
 		</html>
 		`))


### PR DESCRIPTION
Current code fails due to duplicated metrics, this fixes it.
On top of that I've renamed `target` to `zookeeper` and exposed it as static labels, so every metric will be tagged with zk address and chroot path, which will help to avoid more duplicated metrics in case someone have same topics in 2 targets.