### PR TITLE
Change chroot description

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Send a request to collect metrics
 Where:
 
 * zookeeper - required, address of the ZooKeeper used for Kafka, can be multiple addresses separated by comma
-* chroot - required, path inside ZooKeeper where Kafka cluster data is stored
+* chroot - path inside ZooKeeper where Kafka cluster data is stored. Has to be omitted if Kafka resides in the root of ZooKeeper.
 * topics - optional, list of topics to collect metrics for, if empty or missing then all topics will be collected
 
 ## Prometheus configuration


### PR DESCRIPTION
_chroot_ is marked as "required". This is not correct in case the Kafka data is stored in the root of ZooKeeper (which is "/"). Using chroot=/ does not work.
This makes it necessary to change the documentation.