### PR TITLE
Add kafka_broker_is_controller metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ leader is the preferred one.
 This metric will indicate whenever given replica is in sync with the partition
 leader.
 
+### kafka_broker_is_controller
+
+This metric will have value `1` for the broker that is currently the cluster
+controller.
+
 ## Building
 
     go get -u github.com/cloudflare/kafka_zookeeper_exporter

--- a/metrics.go
+++ b/metrics.go
@@ -11,6 +11,23 @@ import (
 	kazoo "github.com/wvanbergen/kazoo-go"
 )
 
+func (c *collector) clusterMetrics(ch chan<- prometheus.Metric, client *kazoo.Kazoo) {
+	controller, err := client.Controller()
+	if err != nil {
+		msg := fmt.Sprintf("Error collecting cluster controller broker ID: %s", err)
+		log.Error(msg)
+		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_controller_id_error", msg, nil, nil), err)
+		return
+	}
+
+	// kafka_broker_is_controller{broker="123"} 1
+	ch <- prometheus.MustNewConstMetric(
+		c.metrics.controller,
+		prometheus.GaugeValue, 1,
+		fmt.Sprint(controller),
+	)
+}
+
 func (c *collector) topicMetrics(ch chan<- prometheus.Metric, topic *kazoo.Topic) {
 	// per partition metrics
 	partitions, err := topic.Partitions()


### PR DESCRIPTION
Exports the current cluster controller with a metric of the form:

    kafka_broker_is_controller{broker="123"} 1

Does not export anything for non-controller brokers.