### PR TITLE
Implement kafka_consumers_offsets metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ leader.
 This metric will have value `1` for the broker that is currently the cluster
 controller.
 
+### kafka_consumers_offsets
+
+The last offset consumed for a given (consumer, topic, partition).
+
+This will only show metrics for legacy consumers that still store their offsets
+in Zookeeper.
+
 ## Building
 
     go get -u github.com/cloudflare/kafka_zookeeper_exporter
@@ -62,13 +69,19 @@ To see the list of avaiable flags run
 
 Send a request to collect metrics
 
-    curl localhost:9381/kafka?zookeeper=10.0.0.1:2181&chroot=/kafka/cluster&topics=mytopic1,mytopic2
+    curl localhost:9381/kafka?zookeeper=10.0.0.1:2181&chroot=/kafka/cluster&topic=mytopic1,mytopic2&consumer=myconsumer1,myconsumer2
 
 Where:
 
 * zookeeper - required, address of the ZooKeeper used for Kafka, can be multiple addresses separated by comma
 * chroot - path inside ZooKeeper where Kafka cluster data is stored. Has to be omitted if Kafka resides in the root of ZooKeeper.
-* topics - optional, list of topics to collect metrics for, if empty or missing then all topics will be collected
+* topic - optional, list of topics to collect metrics for.
+  If empty or missing then all topics will be collected.
+* consumer - optional, list of consumers to collect metrics for.
+  If empty or missing then all consumers will be collected.
+
+If both topic and consumer are non-empty, then metrics where both are relevant
+will only be collected if they match both.
 
 ## Prometheus configuration
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Number of partitions configured for given topic.
 
 ### kafka_topic_partition_replica_count
 
-Number of replicas configured for given topic.
+Number of replicas configured for given partition.
 
 ### kafka_topic_partition_leader
 
@@ -50,6 +50,11 @@ The last offset consumed for a given (consumer, topic, partition).
 
 This will only show metrics for legacy consumers that still store their offsets
 in Zookeeper.
+
+### kafka_zookeeper_scrape_error
+
+Will have value `1` if there was an error retrieving or processing any of the
+data for the current scrape. `0` otherwise.
 
 ## Building
 

--- a/collector.go
+++ b/collector.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +19,7 @@ type zkMetrics struct {
 	partitionISR                  *prometheus.Desc
 	controller                    *prometheus.Desc
 	consumersOffsets              *prometheus.Desc
+	zookeeperScrapeError          *prometheus.Desc
 }
 
 type collector struct {
@@ -28,6 +28,7 @@ type collector struct {
 	topics    []string
 	consumers []string
 	timeout   time.Duration
+	zkErr     int32
 	metrics   zkMetrics
 }
 
@@ -38,6 +39,7 @@ func newCollector(zookeeper string, chroot string, topics []string, consumers []
 		topics:    topics,
 		consumers: consumers,
 		timeout:   *zkTimeout,
+		zkErr:     0,
 		metrics: zkMetrics{
 			topicPartitions: prometheus.NewDesc(
 				"kafka_topic_partition_count",
@@ -59,7 +61,7 @@ func newCollector(zookeeper string, chroot string, topics []string, consumers []
 			),
 			partitionReplicaCount: prometheus.NewDesc(
 				"kafka_topic_partition_replica_count",
-				"Total number of replicas for this topic",
+				"Total number of replicas for this partition",
 				[]string{"topic", "partition"},
 				prometheus.Labels{},
 			),
@@ -81,6 +83,12 @@ func newCollector(zookeeper string, chroot string, topics []string, consumers []
 				[]string{"consumer", "topic", "partition"},
 				prometheus.Labels{},
 			),
+			zookeeperScrapeError: prometheus.NewDesc(
+				"kafka_zookeeper_scrape_error",
+				"1 if there were any errors retrieving data for this scrape, 0 otherwise",
+				[]string{},
+				prometheus.Labels{},
+			),
 		},
 	}
 }
@@ -93,6 +101,7 @@ func (c *collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.metrics.partitionISR
 	ch <- c.metrics.controller
 	ch <- c.metrics.consumersOffsets
+	ch <- c.metrics.zookeeperScrapeError
 }
 
 func (c *collector) Collect(ch chan<- prometheus.Metric) {
@@ -104,57 +113,55 @@ func (c *collector) Collect(ch chan<- prometheus.Metric) {
 	log.Debugf("Connecting to %s, chroot=%s timeout=%s", c.zookeeper, config.Chroot, config.Timeout)
 	client, err := kazoo.NewKazoo(strings.Split(c.zookeeper, ","), &config)
 	if err != nil {
-		msg := fmt.Sprintf("Connection error: %s", err)
-		log.Error(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_error", msg, nil, nil), err)
+		log.Errorf("Connection error: %s", err)
+		// If we can't connect, there's nothing left to do but return the error to the client
+		ch <- prometheus.MustNewConstMetric(c.metrics.zookeeperScrapeError, prometheus.GaugeValue, 1)
 		return
 	}
-
 	defer client.Close()
 
 	c.clusterMetrics(ch, client)
 
+	wg := sync.WaitGroup{}
 	topics, err := client.Topics()
 	if err != nil {
-		msg := fmt.Sprintf("Error collecting list of topics: %s", err)
-		log.Error(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_topic_list_error", msg, nil, nil), err)
-		return
+		log.Errorf("Error collecting list of topics: %s", err)
+		c.zkErr = 1
+	} else {
+		for _, topic := range topics {
+			if len(c.topics) > 0 && !stringInSlice(topic.Name, c.topics) {
+				// skip topic if it's not on the list of topic to collect
+				log.Debugf("Skipping topic '%s', not in list: %s [%d]", topic.Name, c.topics, len(c.topics))
+			} else {
+				wg.Add(1)
+				go func(t *kazoo.Topic) {
+					defer wg.Done()
+					c.topicMetrics(ch, t)
+				}(topic)
+			}
+		}
 	}
 
 	consumers, err := client.Consumergroups()
 	if err != nil {
-		msg := fmt.Sprintf("Error collecting list of consumers: %s", err)
-		log.Error(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_consumer_list_error", msg, nil, nil), err)
-		return
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(len(topics))
-	for _, topic := range topics {
-		go func(cl *collector, cz chan<- prometheus.Metric, t *kazoo.Topic) {
-			defer wg.Done()
-			if len(cl.topics) > 0 && !stringInSlice(t.Name, cl.topics) {
-				// skip topic if it's not on the list of topic to collect
-				log.Debugf("Skipping topic '%s', not in list: %s [%d]", t.Name, cl.topics, len(cl.topics))
-				return
-			}
-			c.topicMetrics(ch, t)
-		}(c, ch, topic)
-	}
-
-	wg.Add(len(consumers))
-	for _, consumer := range consumers {
-		go func(cl *collector, cz chan<- prometheus.Metric, cg *kazoo.Consumergroup) {
-			defer wg.Done()
-			if len(cl.consumers) > 0 && !stringInSlice(cg.Name, cl.consumers) {
+		log.Errorf("Error collecting list of consumers: %s", err)
+		c.zkErr = 1
+	} else {
+		for _, consumer := range consumers {
+			if len(c.consumers) > 0 && !stringInSlice(consumer.Name, c.consumers) {
 				// skip consumer if it's not on the list of consumers to collect
-				log.Debugf("Skipping consumer '%s', not in list: %s [%d]", cg.Name, cl.consumers, len(cl.consumers))
-				return
+				log.Debugf("Skipping consumer '%s', not in list: %s [%d]", consumer.Name, c.consumers, len(c.consumers))
+			} else {
+				wg.Add(1)
+				go func(cg *kazoo.Consumergroup) {
+					defer wg.Done()
+					c.consumerMetrics(ch, cg)
+				}(consumer)
 			}
-			c.consumerMetrics(ch, cg)
-		}(c, ch, consumer)
+		}
 	}
+
 	wg.Wait()
+
+	ch <- prometheus.MustNewConstMetric(c.metrics.zookeeperScrapeError, prometheus.GaugeValue, float64(c.zkErr))
 }

--- a/main.go
+++ b/main.go
@@ -45,8 +45,14 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		topics = strings.Split(topic, ",")
 	}
 
+	consumer := r.URL.Query().Get("consumer")
+	consumers := []string{}
+	if consumer != "" {
+		consumers = strings.Split(consumer, ",")
+	}
+
 	registry := prometheus.NewRegistry()
-	registry.MustRegister(newCollector(zookeeper, chroot, topics))
+	registry.MustRegister(newCollector(zookeeper, chroot, topics, consumers))
 
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)

--- a/metrics.go
+++ b/metrics.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -14,9 +13,8 @@ import (
 func (c *collector) clusterMetrics(ch chan<- prometheus.Metric, client *kazoo.Kazoo) {
 	controller, err := client.Controller()
 	if err != nil {
-		msg := fmt.Sprintf("Error collecting cluster controller broker ID: %s", err)
-		log.Error(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_controller_id_error", msg, nil, nil), err)
+		log.Errorf("Error collecting cluster controller broker ID: %s", err)
+		c.zkErr = 1
 		return
 	}
 
@@ -32,11 +30,11 @@ func (c *collector) topicMetrics(ch chan<- prometheus.Metric, topic *kazoo.Topic
 	// per partition metrics
 	partitions, err := topic.Partitions()
 	if err != nil {
-		msg := fmt.Sprintf("Error collecting list of partitions on '%s' topics: %s", topic.Name, err)
-		log.Errorf(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_topic_partitions_error", msg, nil, nil), err)
+		log.Errorf("Error collecting list of partitions on '%s' topics: %s", topic.Name, err)
+		c.zkErr = 1
 		return
 	}
+
 	// kafka_topic_partition_count{topic="name"} 13
 	ch <- prometheus.MustNewConstMetric(
 		c.metrics.topicPartitions,
@@ -53,7 +51,6 @@ func (c *collector) topicMetrics(ch chan<- prometheus.Metric, topic *kazoo.Topic
 		}(ch, topic, partition)
 	}
 	wg.Wait()
-
 }
 
 // called from topicMetrics() to extract per partition metrics
@@ -67,57 +64,54 @@ func (c *collector) partitionMetrics(ch chan<- prometheus.Metric, topic *kazoo.T
 
 	leader, err := partition.Leader()
 	if err != nil {
-		msg := fmt.Sprintf("Error fetching partition leader for partition %d on topic '%s': %s", partition.ID, topic.Name, err)
-		log.Errorf(msg)
-		ch <- prometheus.NewInvalidMetric(c.metrics.partitionLeader, errors.New(msg))
-		return
-	}
-	// kafka_topic_partition_leader_is_preferred{topic="name", partition="1", replica="10001"} 1
-	ch <- prometheus.MustNewConstMetric(
-		c.metrics.partitionLeader,
-		prometheus.GaugeValue, 1,
-		topic.Name, fmt.Sprint(partition.ID), fmt.Sprint(leader),
-	)
-
-	isr, err := partition.ISR()
-	if err != nil {
-		msg := fmt.Sprintf("Error fetching partition ISR information for partition %d on topic '%s': %s", partition.ID, topic.Name, err)
-		log.Errorf(msg)
-		ch <- prometheus.NewInvalidMetric(c.metrics.partitionISR, errors.New(msg))
-		return
-	}
-	for _, replica := range partition.Replicas {
-		var inSync float64
-		if int32InSlice(replica, isr) {
-			inSync = 1
-		}
-		// kafka_topic_partition_replica_in_sync{topic="name", partition="1", replica="10002"} 0
+		log.Errorf("Error fetching partition leader for partition %d on topic '%s': %s", partition.ID, topic.Name, err)
+		c.zkErr = 1
+	} else {
+		// kafka_topic_partition_leader{topic="name", partition="1", replica="10001"} 1
 		ch <- prometheus.MustNewConstMetric(
-			c.metrics.partitionISR,
-			prometheus.GaugeValue, inSync,
-			topic.Name, fmt.Sprint(partition.ID), fmt.Sprint(replica),
+			c.metrics.partitionLeader,
+			prometheus.GaugeValue, 1,
+			topic.Name, fmt.Sprint(partition.ID), fmt.Sprint(leader),
+		)
+
+		var isPreferred float64
+		if leader == partition.PreferredReplica() {
+			isPreferred = 1
+		}
+		// kafka_topic_partition_leader_is_preferred{topic="name", partition="1"} 1
+		ch <- prometheus.MustNewConstMetric(
+			c.metrics.partitionUsesPreferredReplica,
+			prometheus.GaugeValue, isPreferred,
+			topic.Name, fmt.Sprint(partition.ID),
 		)
 	}
 
-	preferred := partition.PreferredReplica()
-	var isPreferred float64
-	if leader == preferred {
-		isPreferred = 1
+	isr, err := partition.ISR()
+	if err != nil {
+		log.Errorf("Error fetching partition ISR information for partition %d on topic '%s': %s", partition.ID, topic.Name, err)
+		c.zkErr = 1
+	} else {
+		for _, replica := range partition.Replicas {
+			var inSync float64
+			if int32InSlice(replica, isr) {
+				inSync = 1
+			}
+			// kafka_topic_partition_replica_in_sync{topic="name", partition="1", replica="10002"} 0
+			ch <- prometheus.MustNewConstMetric(
+				c.metrics.partitionISR,
+				prometheus.GaugeValue, inSync,
+				topic.Name, fmt.Sprint(partition.ID), fmt.Sprint(replica),
+			)
+		}
 	}
-	// kafka_topic_partition_leader_is_preferred{topic="name", partition="1"} 1
-	ch <- prometheus.MustNewConstMetric(
-		c.metrics.partitionUsesPreferredReplica,
-		prometheus.GaugeValue, isPreferred,
-		topic.Name, fmt.Sprint(partition.ID),
-	)
 }
 
 func (c *collector) consumerMetrics(ch chan<- prometheus.Metric, consumer *kazoo.Consumergroup) {
 	offsets, err := consumer.FetchAllOffsets()
 	if err != nil {
-		msg := fmt.Sprintf("Error collecting offset for consumer %s: %s", consumer.Name, err)
-		log.Errorf(msg)
-		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("zookeeper_consumer_offsets_error", msg, nil, nil), err)
+		log.Errorf("Error collecting offset for consumer %s: %s", consumer.Name, err)
+		c.zkErr = 1
+		// Nothing left to do if we didn't get offsets
 		return
 	}
 


### PR DESCRIPTION
* Export offsets for legacy consumers that store their offsets in Zookeeper.
* Allow optional consumer whitelist.
* Update README.md with the new metric and argument.
* s/topics/topic/ typo fix in README.md.